### PR TITLE
Add overseer access. Closes #102 and #103

### DIFF
--- a/app/api/api_helpers/url_helper.rb
+++ b/app/api/api_helpers/url_helper.rb
@@ -16,6 +16,10 @@ module ApiHelpers
       territory_path(territory)
     end
 
+    def edit_territory(territory)
+      "#{territory_path(territory)}/edit"
+    end
+
     def territory_path(territory)
       frontend_path("/app/territories/#{territory.to_param}")
     end
@@ -40,7 +44,7 @@ module ApiHelpers
       backend_path("/territories/#{territory.to_param}/map/edit")
     end
 
-    def print_territory_map(territory, params = {})
+    def print_territory_map(territory, _params = {})
       backend_path("/territories/#{territory.to_param}/map?print=true")
     end
 

--- a/app/api/api_response/forbidden_response.rb
+++ b/app/api/api_response/forbidden_response.rb
@@ -1,5 +1,9 @@
 module ApiResponse
   class ForbiddenResponse < BaseResponse
+    def to_h
+      { message: 'Forbidden. Not an admin' }
+    end
+
     def status
       400
     end

--- a/app/api/api_response/forbidden_response.rb
+++ b/app/api/api_response/forbidden_response.rb
@@ -1,0 +1,7 @@
+module ApiResponse
+  class ForbiddenResponse < BaseResponse
+    def status
+      400
+    end
+  end
+end

--- a/app/api/api_response/not_found_response.rb
+++ b/app/api/api_response/not_found_response.rb
@@ -1,0 +1,12 @@
+module ApiResponse
+  class NotFoundResponse < BaseResponse
+    def to_h
+      { message: 'Not found' }
+    end
+
+    def status
+      404
+    end
+  end
+end
+

--- a/app/api/api_response/territories/show.rb
+++ b/app/api/api_response/territories/show.rb
@@ -1,8 +1,9 @@
 module ApiResponse
   module Territories
     class Show < BaseResponse
-      def initialize(territory)
+      def initialize(territory, user:)
         @territory = territory
+        @user = user
       end
 
       def to_h
@@ -61,6 +62,10 @@ module ApiResponse
 
       def links(territory)
         values = {}
+
+        unless @user.admin?
+          return values
+        end
 
         if territory.assigned?
           values[:return] = urls.territory_return_path(territory)

--- a/app/api/api_response/territories/show.rb
+++ b/app/api/api_response/territories/show.rb
@@ -67,6 +67,8 @@ module ApiResponse
           return values
         end
 
+        values[:edit] = urls.edit_territory(territory)
+
         if territory.assigned?
           values[:return] = urls.territory_return_path(territory)
         end

--- a/app/api/endpoints/admin_endpoint.rb
+++ b/app/api/endpoints/admin_endpoint.rb
@@ -1,0 +1,17 @@
+module Endpoints
+  class AdminEndpoint < BaseEndpoint
+    def perform(*args)
+      if current_user.admin?
+        return perform_as_admin(*args)
+      end
+
+      ApiResponse::ForbiddenResponse.new
+    end
+
+    private
+
+    def perform_as_admin(*_args)
+      raise 'Method not implemented'
+    end
+  end
+end

--- a/app/api/endpoints/admin_endpoint.rb
+++ b/app/api/endpoints/admin_endpoint.rb
@@ -1,17 +1,12 @@
 module Endpoints
   class AdminEndpoint < BaseEndpoint
+    # admin endpoints should respond to perform_as_admin
     def perform(*args)
       if current_user.admin?
         return perform_as_admin(*args)
       end
 
       ApiResponse::ForbiddenResponse.new
-    end
-
-    private
-
-    def perform_as_admin(*_args)
-      raise 'Method not implemented'
     end
   end
 end

--- a/app/api/endpoints/base_endpoint.rb
+++ b/app/api/endpoints/base_endpoint.rb
@@ -7,5 +7,11 @@ module Endpoints
     private
 
     attr_reader :current_user
+
+    def handle_errors
+      yield
+    rescue ActiveRecord::RecordNotFound
+      ApiResponse::NotFoundResponse.new
+    end
   end
 end

--- a/app/api/endpoints/base_endpoint.rb
+++ b/app/api/endpoints/base_endpoint.rb
@@ -1,0 +1,11 @@
+module Endpoints
+  class BaseEndpoint
+    def initialize(current_user:)
+      @current_user = current_user
+    end
+
+    private
+
+    attr_reader :current_user
+  end
+end

--- a/app/api/endpoints/householders/create_endpoint.rb
+++ b/app/api/endpoints/householders/create_endpoint.rb
@@ -1,7 +1,9 @@
 module Endpoints
   module Householders
-    class CreateEndpoint
-      def perform(territory_slug:, attributes:)
+    class CreateEndpoint < AdminEndpoint
+      private
+
+      def perform_as_admin(territory_slug:, attributes:)
         collection = Territory.find_by_slug(territory_slug).householders
         householder = collection.build(attributes)
 

--- a/app/api/endpoints/householders/create_endpoint.rb
+++ b/app/api/endpoints/householders/create_endpoint.rb
@@ -1,17 +1,17 @@
 module Endpoints
   module Householders
-    class CreateEndpoint < AdminEndpoint
-      private
+    class CreateEndpoint < BaseEndpoint
+      def perform(territory_slug:, attributes:)
+        handle_errors do
+          collection = current_user.territories.find_by_slug(territory_slug).householders
+          householder = collection.build(attributes)
 
-      def perform_as_admin(territory_slug:, attributes:)
-        collection = Territory.find_by_slug(territory_slug).householders
-        householder = collection.build(attributes)
+          if householder.save(attributes)
+            return ApiResponse::Householders::Created.new(householder)
+          end
 
-        if householder.save(attributes)
-          return ApiResponse::Householders::Created.new(householder)
+          ApiResponse::ValidationError.new(householder.errors)
         end
-
-        ApiResponse::ValidationError.new(householder.errors)
       end
     end
   end

--- a/app/api/endpoints/territories/index_endpoint.rb
+++ b/app/api/endpoints/territories/index_endpoint.rb
@@ -1,7 +1,9 @@
 module Endpoints
   module Territories
-    class IndexEndpoint
-      def perform(search_params)
+    class IndexEndpoint < AdminEndpoint
+      private
+
+      def perform_as_admin(search_params)
         territories = TerritoryService.new.search(search_params)
         ApiResponse::Territories::Index.new(territories)
       end

--- a/app/api/endpoints/territories/index_endpoint.rb
+++ b/app/api/endpoints/territories/index_endpoint.rb
@@ -2,7 +2,7 @@ module Endpoints
   module Territories
     class IndexEndpoint < BaseEndpoint
       def perform(search_params)
-        territories = TerritoryService.new.search(search_params)
+        territories = TerritoryService.new(user: current_user).search(search_params)
         ApiResponse::Territories::Index.new(territories)
       end
     end

--- a/app/api/endpoints/territories/index_endpoint.rb
+++ b/app/api/endpoints/territories/index_endpoint.rb
@@ -1,9 +1,7 @@
 module Endpoints
   module Territories
-    class IndexEndpoint < AdminEndpoint
-      private
-
-      def perform_as_admin(search_params)
+    class IndexEndpoint < BaseEndpoint
+      def perform(search_params)
         territories = TerritoryService.new.search(search_params)
         ApiResponse::Territories::Index.new(territories)
       end

--- a/app/api/endpoints/territories/show_endpoint.rb
+++ b/app/api/endpoints/territories/show_endpoint.rb
@@ -2,10 +2,10 @@ module Endpoints
   module Territories
     class ShowEndpoint < BaseEndpoint
       def perform(slug:)
-        territory = current_user.territories.find_by_slug(slug)
-        ApiResponse::Territories::Show.new(territory, user: current_user)
-      rescue ActiveRecord::RecordNotFound
-        ApiResponse::NotFoundResponse.new
+        handle_errors do
+          territory = current_user.territories.find_by_slug(slug)
+          ApiResponse::Territories::Show.new(territory, user: current_user)
+        end
       end
     end
   end

--- a/app/api/endpoints/territories/show_endpoint.rb
+++ b/app/api/endpoints/territories/show_endpoint.rb
@@ -3,7 +3,7 @@ module Endpoints
     class ShowEndpoint < BaseEndpoint
       def perform(slug:)
         territory = current_user.territories.find_by_slug(slug)
-        ApiResponse::Territories::Show.new(territory)
+        ApiResponse::Territories::Show.new(territory, user: current_user)
       rescue ActiveRecord::RecordNotFound
         ApiResponse::NotFoundResponse.new
       end

--- a/app/api/endpoints/territories/show_endpoint.rb
+++ b/app/api/endpoints/territories/show_endpoint.rb
@@ -1,11 +1,11 @@
 module Endpoints
   module Territories
-    class ShowEndpoint < AdminEndpoint
-      private
-
-      def perform_as_admin(slug:)
-        territory = Territory.find_by_slug(slug)
+    class ShowEndpoint < BaseEndpoint
+      def perform(slug:)
+        territory = current_user.territories.find_by_slug(slug)
         ApiResponse::Territories::Show.new(territory)
+      rescue ActiveRecord::RecordNotFound
+        ApiResponse::NotFoundResponse.new
       end
     end
   end

--- a/app/api/endpoints/territories/show_endpoint.rb
+++ b/app/api/endpoints/territories/show_endpoint.rb
@@ -1,7 +1,9 @@
 module Endpoints
   module Territories
-    class ShowEndpoint
-      def perform(slug:)
+    class ShowEndpoint < AdminEndpoint
+      private
+
+      def perform_as_admin(slug:)
         territory = Territory.find_by_slug(slug)
         ApiResponse::Territories::Show.new(territory)
       end

--- a/app/api/endpoints/territories/update_endpoint.rb
+++ b/app/api/endpoints/territories/update_endpoint.rb
@@ -7,7 +7,7 @@ module Endpoints
         territory = Territory.find_by_slug(slug)
 
         if territory.update(attributes)
-          return ApiResponse::Territories::Updated.new(territory)
+          return ApiResponse::Territories::Updated.new(territory, user: current_user)
         end
 
         ApiResponse::ValidationError.new(territory.errors)

--- a/app/api/endpoints/territories/update_endpoint.rb
+++ b/app/api/endpoints/territories/update_endpoint.rb
@@ -1,7 +1,9 @@
 module Endpoints
   module Territories
-    class UpdateEndpoint
-      def perform(slug:, attributes:)
+    class UpdateEndpoint < AdminEndpoint
+      private
+
+      def perform_as_admin(slug:, attributes:)
         territory = Territory.find_by_slug(slug)
 
         if territory.update(attributes)

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -8,7 +8,8 @@ module Api
       endpoint = params[:action].classify
       module_name = self.class.to_s.split('::').last.gsub('Controller', '')
       class_name = "Endpoints::#{module_name}::#{endpoint}Endpoint"
-      response = class_name.constantize.new.perform(*payload)
+      klass = class_name.constantize
+      response = klass.new(current_user: current_user).perform(*payload)
 
       render json: response.to_h, status: response.status
     end

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -2,6 +2,8 @@ module Api
   class ApiController < AuthenticatedController
     skip_before_action :require_admin
 
+    private
+
     # Map controller + action to endpoint. I.E.
     # TerritoriesController#show => Endpoints::Territories::ShowEndpoint
     # Then instantiate it and delegates payload to the perform method

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -1,5 +1,6 @@
 module Api
   class ApiController < AuthenticatedController
+    skip_before_action :require_admin
 
     # Map controller + action to endpoint. I.E.
     # TerritoriesController#show => Endpoints::Territories::ShowEndpoint

--- a/app/controllers/api/publishers_controller.rb
+++ b/app/controllers/api/publishers_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class PublishersController < AuthenticatedController
+    skip_before_action :require_admin
+
     def index
       publishers = Publisher.all.sorted
       response = ApiResponse::Publishers::Index.new(publishers)

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,5 +1,6 @@
 class AuthenticatedController < ApplicationController
   before_action :require_login
+  before_action :require_admin
   before_action :set_authenticity_token
 
   private
@@ -10,5 +11,11 @@ class AuthenticatedController < ApplicationController
 
   def set_authenticity_token
     cookies[:fs_form_token] = form_authenticity_token
+  end
+
+  def require_admin
+    unless current_user.admin?
+      redirect_to urls.territory_index_path
+    end
   end
 end

--- a/app/controllers/householders_controller.rb
+++ b/app/controllers/householders_controller.rb
@@ -1,4 +1,6 @@
 class HouseholdersController < AuthenticatedController
+  skip_before_action :require_admin
+
   def index
     householders = territory.householders
     @householders_decorator = create_decorator(HouseholdersDecorator, householders, territory)
@@ -75,7 +77,7 @@ class HouseholdersController < AuthenticatedController
   private
 
   def territory
-    @_territory ||= Territory.find_by_slug(params[:territory_slug])
+    @_territory ||= current_user.territories.find_by_slug(params[:territory_slug])
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,4 +1,5 @@
 class MapsController < AuthenticatedController
+  skip_before_action :require_admin, only: [:show]
   layout 'google_maps'
 
   def show
@@ -22,6 +23,6 @@ class MapsController < AuthenticatedController
   private
 
   def territory
-    @territory ||= Territory.find_by_slug(params[:territory_slug])
+    @territory ||= current_user.territories.find_by_slug(params[:territory_slug])
   end
 end

--- a/app/controllers/reports/inactive_territories_controller.rb
+++ b/app/controllers/reports/inactive_territories_controller.rb
@@ -2,7 +2,7 @@ module Reports
   class InactiveTerritoriesController < ApplicationController
     def index
       if from
-        territories = TerritoryService.new.inactive(from: from)
+        territories = TerritoryService.new(user: current_user).inactive(from: from)
         @territories_decorator = create_decorator(TerritoriesDecorator, territories)
       end
     end

--- a/app/controllers/territories_controller.rb
+++ b/app/controllers/territories_controller.rb
@@ -1,4 +1,6 @@
 class TerritoriesController < AuthenticatedController
+  skip_before_action :require_admin, only: [:show]
+
   def index
     @territories = TerritoryService.new(user: current_user).search(search_params)
     @territories_decorator = create_decorator(TerritoriesDecorator, @territories)

--- a/app/controllers/territories_controller.rb
+++ b/app/controllers/territories_controller.rb
@@ -1,6 +1,6 @@
 class TerritoriesController < AuthenticatedController
   def index
-    @territories = TerritoryService.new.search(search_params)
+    @territories = TerritoryService.new(user: current_user).search(search_params)
     @territories_decorator = create_decorator(TerritoriesDecorator, @territories)
 
     respond_to do |format|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,12 @@
 class User < ApplicationRecord
   include Clearance::User
+
+  def territories
+    if admin?
+      return Territory.all
+    end
+
+    publisher_ids = UserPublisher.where(user_id: id).select(:publisher_id)
+    Territory.where(responsible_id: publisher_ids)
+  end
 end

--- a/app/models/user_publisher.rb
+++ b/app/models/user_publisher.rb
@@ -1,0 +1,2 @@
+class UserPublisher < ApplicationRecord
+end

--- a/app/models/user_publisher.rb
+++ b/app/models/user_publisher.rb
@@ -1,2 +1,4 @@
 class UserPublisher < ApplicationRecord
+  belongs_to :user
+  belongs_to :publisher
 end

--- a/app/services/territory_service.rb
+++ b/app/services/territory_service.rb
@@ -1,6 +1,10 @@
 class TerritoryService
+  def initialize(user:)
+    @user = user
+  end
+
   def search(assigned_to_ids: nil, pending_return: nil, inactive_from: nil)
-    query = TerritoryQuery.new
+    query = new_query
 
     if inactive_from
       query = query.inactive(from: inactive_from)
@@ -18,16 +22,29 @@ class TerritoryService
   end
 
   def inactive(from:)
-    TerritoryQuery.new.inactive(from: from)
+    new_query.inactive(from: from)
   end
 
   def worked(from:)
-    TerritoryQuery.new.worked(from: from)
+    new_query.worked(from: from)
+  end
+
+  private
+
+  def new_query
+    TerritoryQuery.new(user: @user)
   end
 end
 
 class TerritoryQuery < SimpleDelegator
-  def initialize(scope = Territory.sorted)
+  def initialize(user: nil, scope: nil)
+    args = [user, scope].compact
+
+    if args.length != 1
+      raise ArgumentError, 'provide either user or scope'
+    end
+
+    scope ||= user.territories.sorted
     super(scope)
   end
 
@@ -62,7 +79,7 @@ class TerritoryQuery < SimpleDelegator
   private
 
   def new(scope)
-    self.class.new(scope)
+    self.class.new(scope: scope)
   end
 
   def scope

--- a/client/src/utils/spec/url-helper.test.js
+++ b/client/src/utils/spec/url-helper.test.js
@@ -24,4 +24,21 @@ describe('UrlHelper', () => {
       expect(url).toEqual('/foo/bar?foo[]=1&foo[]=2')
     });
   });
+
+  describe('.onlyPath', () => {
+    const assertOnlyPath = (input, expected) => {
+      expect(helper.onlyPath(input)).toEqual(expected);
+    };
+
+    it('removes hostname config from url', () => {
+      assertOnlyPath('http://localhost:3001/foo/bar', '/foo/bar');
+      assertOnlyPath('https://localhost:4000/foo/bar', '/foo/bar');
+      assertOnlyPath('http://localhost:4000/foo/bar', '/foo/bar');
+      assertOnlyPath('http://localhost/foo/bar', '/foo/bar');
+      assertOnlyPath('http://127.1.2.3/foo/bar', '/foo/bar');
+      assertOnlyPath('http://dev.fs.com/foo/bar', '/foo/bar');
+      assertOnlyPath('/foo/bar', '/foo/bar');
+      assertOnlyPath('http://localhost:3001/app/territories/001/edit', '/app/territories/001/edit')
+    });
+  });
 });

--- a/client/src/utils/url-helper.js
+++ b/client/src/utils/url-helper.js
@@ -12,4 +12,8 @@ export default class UrlHelper {
 
     return url;
   }
+
+  static onlyPath(url) {
+    return url.replace(/^(http(s)?:\/\/[\da-z.]+(:[\d]+)?)?/, '');
+  }
 }

--- a/client/src/views/pages/territories/show.js
+++ b/client/src/views/pages/territories/show.js
@@ -21,7 +21,9 @@ const renderActions = withRouter(({ territory, history }) => {
 
   if (territory.links.return) {
     assignmentButton = <ReturnTerritoryButton className={ classes } territory={ territory } />;
-  } else {
+  }
+
+  if (territory.links.assign) {
     assignmentButton = <Button className={ classes } href={ territory.links.assign }>{ t.assignTerritory }</Button>;
   }
 

--- a/client/src/views/pages/territories/show.js
+++ b/client/src/views/pages/territories/show.js
@@ -3,6 +3,7 @@ import LeftRightFrame from '../../components/left-right-frame';
 import ContentToggler from '../../components/content-toggler';
 import Date from '../../components/date';
 import appRoutes from '../../../app-routes';
+import urlHelper from '../../../utils/url-helper';
 import LoaderOrContent from '../../components/loader-or-content';
 import Item from '../../components/property-value-label';
 import Button from '../../components/button';
@@ -18,6 +19,7 @@ import styles from '../../../global.css';
 const renderActions = withRouter(({ territory, history }) => {
   const classes = [styles.wide, styles.fullLine, styles.decolapseDown];
   let assignmentButton = null;
+  let editButton = null;
 
   if (territory.links.return) {
     assignmentButton = <ReturnTerritoryButton className={ classes } territory={ territory } />;
@@ -27,11 +29,15 @@ const renderActions = withRouter(({ territory, history }) => {
     assignmentButton = <Button className={ classes } href={ territory.links.assign }>{ t.assignTerritory }</Button>;
   }
 
+  if (territory.links.edit) {
+    editButton = <Button className={classes} onClick={ () => history.push(urlHelper.onlyPath(territory.links.edit)) } >{ t.edit }</Button>;
+  }
+
   return (
     <div>
       <Button className={classes} onClick={ () => history.push(appRoutes.territories.index()) } >{ t.back }</Button>
       <Button className={classes} target="_blank" href={ appRoutes.territories.pdf(territory.slug) } >{ t.downloadPdf }</Button>
-      <Button className={classes} onClick={ () => history.push(appRoutes.territories.edit(territory.slug)) } >{ t.edit }</Button>
+      { editButton }
       { assignmentButton }
       <Button className={ classes } href={ appRoutes.territories.map(territory.slug)  } >{ t.showMap }</Button>
     </div>

--- a/db/migrate/20180306191635_create_user_publisher.rb
+++ b/db/migrate/20180306191635_create_user_publisher.rb
@@ -1,0 +1,8 @@
+class CreateUserPublisher < ActiveRecord::Migration[5.0]
+  def change
+    create_table :user_publishers do |t|
+      t.references :user, foreign_key: true
+      t.references :publisher, foreign_key: true
+    end
+  end
+end

--- a/spec/api/api_response/forbidden_response_spec.rb
+++ b/spec/api/api_response/forbidden_response_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ApiResponse::ForbiddenResponse do
+  it 'responds with 400' do
+    expect(subject.status).to be 400
+  end
+
+  it 'responds with correct message' do
+    expect(subject.to_h).to eq(message: 'Forbidden. Not an admin')
+  end
+end

--- a/spec/api/api_response/not_found_response_spec.rb
+++ b/spec/api/api_response/not_found_response_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe ApiResponse::NotFoundResponse do
+  it 'responds with 400' do
+    expect(subject.status).to be 404
+  end
+
+  it 'responds with correct message' do
+    expect(subject.to_h).to eq(message: 'Not found')
+  end
+end
+

--- a/spec/api/api_response/territories/show_spec.rb
+++ b/spec/api/api_response/territories/show_spec.rb
@@ -1,9 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe ApiResponse::Territories::Show do
+  subject { described_class.new(territory, user: user) }
+
   let(:territory) { Territory.new }
-  subject  { described_class.new(territory) }
+  let(:user) { User.new(admin: true) }
   let(:data_hash) { subject.to_h[:data] }
+
+  before do
+    allow_any_instance_of(ApiHelpers::UrlHelper).to receive(:territory_return_path)
+      .with(territory) { '/return' }
+    allow_any_instance_of(ApiHelpers::UrlHelper).to receive(:territory_assign_path)
+      .with(territory) { '/assign' }
+  end
 
   describe '#to_h' do
     it 'returns empty coordinates when not present' do
@@ -27,6 +36,50 @@ RSpec.describe ApiResponse::Territories::Show do
         id: 1,
         name: 'John'
       )
+    end
+  end
+
+  describe 'links' do
+    describe 'when user is an admin' do
+      it 'includes return link when territory is assigned' do
+        allow(territory).to receive(:assigned?) { true }
+
+        expect(data_hash[:links][:return]).to eq('/return')
+      end
+
+      it 'does not include return link when territory is assigned' do
+        allow(territory).to receive(:assigned?) { false }
+
+        expect(data_hash[:links][:return]).to be_nil
+      end
+
+      it 'includes assign link when territory is assigned' do
+        allow(territory).to receive(:assigned?) { false }
+
+        expect(data_hash[:links][:assign]).to eq('/assign')
+      end
+
+      it 'does not include assign link when territory is assigned' do
+        allow(territory).to receive(:assigned?) { true }
+
+        expect(data_hash[:links][:assign]).to be_nil
+      end
+    end
+
+    describe 'when user is not an admin' do
+      let(:user) { User.new(admin: false) }
+
+      it 'does not include return link when territory is assigned' do
+        allow(territory).to receive(:assigned?) { true }
+
+        expect(data_hash[:links][:return]).to be_nil
+      end
+
+      it 'does not include assign link when territory is assigned' do
+        allow(territory).to receive(:assigned?) { false }
+
+        expect(data_hash[:links][:assign]).to be_nil
+      end
     end
   end
 end

--- a/spec/api/api_response/territories/show_spec.rb
+++ b/spec/api/api_response/territories/show_spec.rb
@@ -10,8 +10,12 @@ RSpec.describe ApiResponse::Territories::Show do
   before do
     allow_any_instance_of(ApiHelpers::UrlHelper).to receive(:territory_return_path)
       .with(territory) { '/return' }
+
     allow_any_instance_of(ApiHelpers::UrlHelper).to receive(:territory_assign_path)
       .with(territory) { '/assign' }
+
+    allow_any_instance_of(ApiHelpers::UrlHelper).to receive(:edit_territory)
+      .with(territory) { '/edit' }
   end
 
   describe '#to_h' do
@@ -41,6 +45,10 @@ RSpec.describe ApiResponse::Territories::Show do
 
   describe 'links' do
     describe 'when user is an admin' do
+      it 'includes edit link when' do
+        expect(data_hash[:links][:edit]).to eq('/edit')
+      end
+
       it 'includes return link when territory is assigned' do
         allow(territory).to receive(:assigned?) { true }
 
@@ -68,6 +76,10 @@ RSpec.describe ApiResponse::Territories::Show do
 
     describe 'when user is not an admin' do
       let(:user) { User.new(admin: false) }
+
+      it 'does not includes edit link when' do
+        expect(data_hash[:links][:edit]).to be_nil
+      end
 
       it 'does not include return link when territory is assigned' do
         allow(territory).to receive(:assigned?) { true }

--- a/spec/api/endpoints/admin_endpoint_spec.rb
+++ b/spec/api/endpoints/admin_endpoint_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+class DummyAdminEndpoint < Endpoints::AdminEndpoint
+  private
+
+  def perform_as_admin(*args)
+    args
+  end
+end
+
+RSpec.describe Endpoints::AdminEndpoint, type: :endpoint do
+  subject { DummyAdminEndpoint.new(current_user: current_user) }
+
+  describe 'perform' do
+    context 'as non admin' do
+      let(:current_user) { User.new(admin: false) }
+
+      it 'returns with a forbidden answer when user is not an admin' do
+        expect(subject.perform).to be_a(ApiResponse::ForbiddenResponse)
+      end
+    end
+
+    context 'as non admin' do
+      let(:current_user) { User.new(admin: true) }
+
+      it 'returns the response from #perform_as_admin method' do
+        expect(subject.perform(1, 2)).to eq([1, 2])
+      end
+    end
+  end
+end

--- a/spec/api/endpoints/base_endpoint_spec.rb
+++ b/spec/api/endpoints/base_endpoint_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+class DummyEndpoint < Endpoints::BaseEndpoint
+  def user
+    current_user
+  end
+end
+
+RSpec.describe Endpoints::BaseEndpoint do
+  let(:user) { double(:user) }
+  subject { DummyEndpoint.new(current_user: user) }
+
+  it 'takes an user in the initializer' do
+    expect(subject.user).to be(user)
+  end
+end

--- a/spec/api/endpoints/householders/create_endpoint_spec.rb
+++ b/spec/api/endpoints/householders/create_endpoint_spec.rb
@@ -1,5 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe Endpoints::Householders::CreateEndpoint, type: :endpoint do
-  is_admin_endpoint
+  is_not_admin_endpoint
+
+  let(:attributes) { { some: :attributes } }
+
+  describe '#perform' do
+    context 'when territory is not found' do
+      it 'responds with not found' do
+        response = subject.perform(territory_slug: 'the-slug', attributes: attributes)
+
+        expect(response).to be_equal_to(ApiResponse::NotFoundResponse.new)
+      end
+    end
+
+    context 'when territory is found' do
+      let(:territories) { class_double(Territory) }
+      let(:territory) { Territory.make!(name: 'the name') }
+      let(:perform) { subject.perform(territory_slug: 'the-name', attributes: attributes) }
+
+      before do
+        expect(current_user).to receive(:territories).and_return(territories)
+        expect(territories).to receive(:find_by_slug).with('the-name').and_return(territory)
+      end
+
+      context 'with valid payload' do
+        let(:attributes) do
+          {
+            name: 'the-name',
+            show: true,
+            street_name: 'the street name',
+            house_number: 'the house number'
+          }
+        end
+
+        it 'creates a new housholder' do
+          expect { perform }.to change { territory.householders.count }.by(1)
+
+          expected_resonse = ApiResponse::Householders::Created.new(Householder.last)
+
+          expect(perform).to be_equal_to(expected_resonse)
+        end
+      end
+
+      context 'with invalid payload' do
+        let(:attributes) { { name: 'the-name' } }
+
+        it 'creates a new housholder' do
+          expect(perform).to be_a(ApiResponse::ValidationError)
+        end
+      end
+    end
+  end
 end

--- a/spec/api/endpoints/householders/create_endpoint_spec.rb
+++ b/spec/api/endpoints/householders/create_endpoint_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Endpoints::Householders::CreateEndpoint, type: :endpoint do
+  is_admin_endpoint
+end

--- a/spec/api/endpoints/territories/index_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/index_endpoint_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Endpoints::Territories::IndexEndpoint, type: :endpoint do
+  is_admin_endpoint
+end

--- a/spec/api/endpoints/territories/index_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/index_endpoint_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe Endpoints::Territories::IndexEndpoint, type: :endpoint do
-  is_admin_endpoint
 end

--- a/spec/api/endpoints/territories/index_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/index_endpoint_spec.rb
@@ -1,4 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Endpoints::Territories::IndexEndpoint, type: :endpoint do
+  let(:service) { instance_double(TerritoryService) }
+  let(:territories) { [Territory.new] }
+  let(:params) { { assigned_to_ids: :bar } }
+
+  before do
+    allow(TerritoryService).to receive(:new).with(user: current_user) { service }
+    allow(service).to receive(:search).with(params).and_return(territories)
+  end
+
+  describe '#perform' do
+    it 'returns a response for the given user' do
+      response = subject.perform(params)
+
+      expect(response).to be_equal_to(ApiResponse::Territories::Index.new(territories))
+    end
+  end
 end

--- a/spec/api/endpoints/territories/show_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/show_endpoint_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Endpoints::Territories::ShowEndpoint, type: :endpoint do
     end
 
     it 'returns the user territories when found' do
-      response = ApiResponse::Territories::Show.new(territory)
+      response = ApiResponse::Territories::Show.new(territory, user: current_user)
 
       expect(subject.perform(slug: 'the-slug')).to be_equal_to(response)
     end

--- a/spec/api/endpoints/territories/show_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/show_endpoint_spec.rb
@@ -1,5 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Endpoints::Territories::ShowEndpoint, type: :endpoint do
-  is_admin_endpoint
+  is_not_admin_endpoint
+
+  let(:territories) { double(:territories) }
+  let(:territory) { Territory.new(name: 'foo') }
+
+  before do
+    allow(current_user).to receive(:territories).and_return(territories)
+  end
+
+  context 'when territory is found' do
+    before do
+      allow(territories).to receive(:find_by_slug).with('the-slug').and_return(territory)
+    end
+
+    it 'returns the user territories when found' do
+      response = ApiResponse::Territories::Show.new(territory)
+
+      expect(subject.perform(slug: 'the-slug')).to be_equal_to(response)
+    end
+  end
+
+  context 'when territory is not found' do
+    before do
+      allow(territories).to receive(:find_by_slug).with('the-slug') do
+        raise ActiveRecord::RecordNotFound, 'Record not found'
+      end
+    end
+
+    it 'returns the user territories when found' do
+      response = ApiResponse::NotFoundResponse.new
+
+      expect(subject.perform(slug: 'the-slug')).to be_equal_to(response)
+    end
+  end
 end

--- a/spec/api/endpoints/territories/show_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/show_endpoint_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Endpoints::Territories::ShowEndpoint, type: :endpoint do
+  is_admin_endpoint
+end

--- a/spec/api/endpoints/territories/update_endpoint_spec.rb
+++ b/spec/api/endpoints/territories/update_endpoint_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Endpoints::Territories::UpdateEndpoint, type: :endpoint do
+  is_admin_endpoint
+end

--- a/spec/controllers/api/territories_controller_spec.rb
+++ b/spec/controllers/api/territories_controller_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Api::TerritoriesController, type: :controller do
     end
 
     it 'can be used to delete mapped coordinates' do
-      sign_in_as(current_user)
+      sign_in_as_admin
 
       territory = Territory.make!(map_coordinates: [{ foo: :bar }])
 

--- a/spec/controllers/householders_controller_spec.rb
+++ b/spec/controllers/householders_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe HouseholdersController, type: :controller do
-  let(:current_user) { User.make!(password: 'admin') }
+  let(:current_user) { User.make(password: 'admin', admin: true) }
   let(:territory) { Territory.make! }
   let(:householder) { Householder.make!(territory: territory) }
   let(:decorator) { HouseholderDecorator.new(householder) }
@@ -30,13 +30,25 @@ RSpec.describe HouseholdersController, type: :controller do
     assert subject.is_a?(AuthenticatedController)
   end
 
-  it 'should get index' do
-    Householder.where(territory_id: territory.id).count
+  describe '#index' do
+    context 'when user is not admin' do
+      let(:current_user) { User.new(admin: false) }
 
-    get :index, params: { territory_slug: territory.to_param }
+      it 'redirects to the react page of territories' do
+        get :index, params: { territory_slug: territory.to_param }
 
-    assert_response :success
-    assert_equal 1, assigns(:householders_decorator).send(:collection).count
+        expect(response).to redirect_to('/app/territories')
+      end
+    end
+
+    it 'should get index' do
+      Householder.where(territory_id: territory.id).count
+
+      get :index, params: { territory_slug: territory.to_param }
+
+      assert_response :success
+      assert_equal 1, assigns(:householders_decorator).send(:collection).count
+    end
   end
 
   it 'should get index as csv' do

--- a/spec/controllers/householders_controller_spec.rb
+++ b/spec/controllers/householders_controller_spec.rb
@@ -71,14 +71,18 @@ RSpec.describe HouseholdersController, type: :controller do
     expect_any_instance_of(Householder).to receive(:update_geolocation)
 
     expect do
-      post :create, params: { territory_slug: territory.to_param }.merge(householder: householder_params)
+      post :create, params: { territory_slug: territory.to_param }.merge(
+        householder: householder_params
+      )
     end.to change { territory.householders.count }.by(1)
 
     assert_redirected_to "/app/territories/#{householder.territory.to_param}"
   end
 
   it 're-render form when create fails' do
-    params = { territory_slug: territory.to_param }.merge(householder: householder_params.merge(name: ''))
+    params = { territory_slug: territory.to_param }.merge(
+      householder: householder_params.merge(name: '')
+    )
 
     post :create, params: params
 
@@ -100,7 +104,11 @@ RSpec.describe HouseholdersController, type: :controller do
   it 'should update householder' do
     expect_any_instance_of(Householder).to receive(:update_geolocation)
 
-    params = { territory_slug: territory.to_param, id: householder.id, householder: householder_params }
+    params = {
+      territory_slug: territory.to_param,
+      id: householder.id,
+      householder: householder_params
+    }
 
     patch :update, params: params
 

--- a/spec/controllers/maps_controller_spec.rb
+++ b/spec/controllers/maps_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MapsController, type: :controller do
   before do
-    sign_in_as(current_user)
+    sign_in_as_admin
   end
 
   let(:territory) { Territory.make!(map_coordinates: [{ lat: 1, lng: 1 }]) }

--- a/spec/controllers/publishers_controller_spec.rb
+++ b/spec/controllers/publishers_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe PublishersController do
-  let(:current_user) { User.make! }
-
   before do
     @publisher = Publisher.make!
     @decorator = PublisherDecorator.new(@publisher)
@@ -17,7 +15,7 @@ RSpec.describe PublishersController do
       phone: @publisher.phone,
       congregation_member: 1
     }
-    sign_in_as(current_user)
+    sign_in_as_admin
   end
 
   def resource_url(resource = @resource)

--- a/spec/controllers/territories_controller_spec.rb
+++ b/spec/controllers/territories_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe TerritoriesController do
-  let(:current_user) { User.make! }
   before do
     @territory = Territory.make!
     @decorator = TerritoryDecorator.new(@territory)
@@ -18,7 +17,7 @@ RSpec.describe TerritoriesController do
       responsible_id: @publisher.id
     }
 
-    sign_in_as(current_user)
+    sign_in_as_admin
   end
 
   def resource_url(resource = @resource)

--- a/spec/controllers/territory_assignments_controller_spec.rb
+++ b/spec/controllers/territory_assignments_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe TerritoryAssignmentsController do
   before do
-    sign_in_as(User.new)
+    sign_in_as_admin
   end
 
   it 'is authenticated controller' do

--- a/spec/models/user_publisher_spec.rb
+++ b/spec/models/user_publisher_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe UserPublisher do
+  it 'belongs to user and publisher' do
+    UserPublisher.create!(user: User.make!, publisher: Publisher.make!)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe User do
+  describe '#territories' do
+    context 'when user is admin' do
+      let(:user) { User.new(admin: true) }
+
+      it 'returns all the territories' do
+        territories = double(:territories)
+
+        allow(Territory).to receive(:all).and_return(territories)
+
+        expect(user.territories).to be territories
+      end
+    end
+
+    context 'when user is not an admin' do
+      let(:user) { User.make!(admin: false) }
+      let(:publisher1) { Publisher.make! }
+      let(:publisher2) { Publisher.make! }
+      let(:territory1) { Territory.make!(responsible_id: publisher1.id) }
+      let(:territory2) { Territory.make!(responsible_id: publisher2.id) }
+      let(:territory3) { Territory.make! }
+
+      before do
+        UserPublisher.create!(user_id: user.id, publisher_id: publisher1.id)
+        UserPublisher.create!(user_id: user.id, publisher_id: publisher2.id)
+
+        territory1
+        territory2
+        territory3
+      end
+
+      it 'returns only the territories that the user is responsible for' do
+        expect(user.territories).to eq([territory1, territory2])
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,12 +36,14 @@ require "clearance/rspec"
 
 require File.expand_path(File.dirname(__FILE__) + '/support/blueprints')
 require File.expand_path(File.dirname(__FILE__) + '/support/api/controller_spec_helper')
+require File.expand_path(File.dirname(__FILE__) + '/support/endpoint_spec_helper')
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
+  config.include EndpointSpecHelper, type: :endpoint
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 

--- a/spec/support/api/controller_spec_helper.rb
+++ b/spec/support/api/controller_spec_helper.rb
@@ -4,11 +4,8 @@ module Api
   module ControllerSpecHelper
     def self.included(base)
       base.class_eval do
-        before do
-          allow_any_instance_of(Api::ApiController).to receive(:current_user) { current_user }
-        end
-
         let(:current_user) { User.new }
+        let(:admin_user) { User.new(admin: true) }
       end
     end
 
@@ -32,6 +29,10 @@ module Api
       sign_in_as(current_user)
       mock_controller_rendering
       expect_any_instance_of(Api::ApiController).to receive(:perform_with).with(*args)
+    end
+
+    def sign_in_as_admin
+      sign_in_as(User.new(admin: true))
     end
   end
 end

--- a/spec/support/endpoint_spec_helper.rb
+++ b/spec/support/endpoint_spec_helper.rb
@@ -6,6 +6,18 @@ module EndpointSpecHelper
       subject do
         described_class.new(current_user: current_user)
       end
+
+      base.extend(ClassMethods)
+    end
+  end
+
+  module ClassMethods
+    def is_admin_endpoint
+      it 'is an admin endpoint' do
+        expect(subject).to be_a(Endpoints::AdminEndpoint)
+        expect(subject.respond_to?(:perform_as_admin, false)).to be false
+        expect(subject.respond_to?(:perform_as_admin, true)).to be true
+      end
     end
   end
 end

--- a/spec/support/endpoint_spec_helper.rb
+++ b/spec/support/endpoint_spec_helper.rb
@@ -19,5 +19,11 @@ module EndpointSpecHelper
         expect(subject.respond_to?(:perform_as_admin, true)).to be true
       end
     end
+
+    def is_not_admin_endpoint
+      it 'is not an admin endpoint' do
+        expect(subject).not_to be_a(Endpoints::AdminEndpoint)
+      end
+    end
   end
 end

--- a/spec/support/endpoint_spec_helper.rb
+++ b/spec/support/endpoint_spec_helper.rb
@@ -1,0 +1,11 @@
+module EndpointSpecHelper
+  def self.included(base)
+    base.class_eval do
+      let(:current_user) { User.new(admin: true) }
+
+      subject do
+        described_class.new(current_user: current_user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] A table should be create to associate publishers to users (publishers_users)
- [x] Admin users can list/change all territories, publishers and so on
- [x] Non admins cannot list/change publishers
- [x] Non admins cannot change territory primary properties
- [x] Non admins can list their territories
- [x] Non admins can view their territories householders
- [x] Non admins cannnot assign territories
- [x] Non admins cannnot mark return territoriers

Non admins:

- [x] Remove assign link
- [x] Remove return link
- [x] Remove territory edit link
- [x] Remove territory remove link
- [x] Permit Add housholders for own territories
- [x] Permit edit housholders for own territories
- [x] Permit edit housholders for own territories legacy
- [x] Permit remove housholders for own territories
- [x] Permit download pdf for own territories
- [x] Permit show map for own territories
